### PR TITLE
Partial fix to Title information

### DIFF
--- a/metroninfoxml.py
+++ b/metroninfoxml.py
@@ -420,7 +420,7 @@ class MetronInfo(Tag):
             else:
                 split_titles = md.title.split(';')
                 for title in split_titles:
-                    add_element(metron_stories, 'Story', title)
+                    add_element(metron_stories, 'Story', title.strip())
 
         if md.manga is not None and md.manga.casefold().startswith('yes'):
             md.genres.add('Manga')


### PR DESCRIPTION
This PR is a partial fix for the Story element. Currently the plugin produces this when the metadata has multiple stories, note the unnecessary empty space at the beginning of the elements after the first:
```
  <Stories>
    <Story>Howl: Contagion</Story>
    <Story> Ziva Kwitney</Story>
    <Story> Self-Defense</Story>
  </Stories>
```
This PR simply strips any empty space around the title, but to properly fix this the GenericMetadata in ComicTagger should be modified to use a list of strings instead of just a string, and any concatenation should be handled in the metadata plugin. Leaving it as is will result in lossy data, for any title that contains a comma in it (which is fairly common occurrence).