### PR TITLE
Fix project import

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
 
-from .acbfxml import ACBF
+from .metroninfoxml import MetronInfo
 
-__all__ = ['ACBF']
+__all__ = ['MetronInfo']


### PR DESCRIPTION
Looks like the project import was using another projects info, which potentially cause some unexpected behavior if the user was using the referenced plugin.

This PR simply updates it with *this* projects class